### PR TITLE
feat: allow inviting users to lesson plan

### DIFF
--- a/src/app/lesson-plan/invite/[id]/page.tsx
+++ b/src/app/lesson-plan/invite/[id]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { HttpRequest } from "@/utils/http-request";
+import useAuth from "@/hooks/useAuth";
+import Button from "@/components/ui/button/Button";
+import { jwtDecode } from "jwt-decode";
+import { useRouter } from "next/navigation";
+
+interface TokenPayload {
+  _id: string;
+}
+
+export default function InvitePage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  useAuth();
+  const router = useRouter();
+  const { id } = params;
+  const [planName, setPlanName] = useState<string>("");
+
+  useEffect(() => {
+    const fetchPlan = async () => {
+      const httpRequest = new HttpRequest();
+      const plan = await httpRequest.getLessonPlanById(id);
+      setPlanName(plan?.name || "");
+    };
+    if (id) {
+      fetchPlan();
+    }
+  }, [id]);
+
+  const handleJoin = async () => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+    const decoded = jwtDecode<TokenPayload>(token);
+    const httpRequest = new HttpRequest();
+    await httpRequest.inviteUserToLessonPlan(id, decoded._id);
+    router.push(`/lesson-plan/details/${id}`);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <h1 className="text-xl font-semibold">{planName}</h1>
+      <Button onClick={handleJoin}>Entrar</Button>
+    </div>
+  );
+}
+

--- a/src/components/lesson-plan/LessonPlanCard.tsx
+++ b/src/components/lesson-plan/LessonPlanCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PencilIcon, Trash2Icon } from "lucide-react";
+import { PencilIcon, Trash2Icon, UserPlusIcon } from "lucide-react";
 
 import Button from "../ui/button/Button";
 import { HttpRequest } from "@/utils/http-request";
@@ -47,6 +47,12 @@ const LessonPlanCard: React.FC<LessonPlanCardProps> = ({
     onUpdateSuccess();
   };
 
+  const handleInvite = async () => {
+    const inviteLink = `${window.location.origin}/lesson-plan/invite/${lessonPlanId}`;
+    await navigator.clipboard.writeText(inviteLink);
+    alert("Link copiado!");
+  };
+
   return (
     <>
       <div className="relative group rounded-2xl border border-gray-200 bg-white px-6 pb-5 pt-6 overflow-hidden transition-shadow hover:shadow-md dark:border-gray-800 dark:bg-white/[0.03]">
@@ -76,6 +82,17 @@ const LessonPlanCard: React.FC<LessonPlanCardProps> = ({
 
         {/* overlay com botões */}
         <div className="absolute inset-0 bg-black/40 backdrop-blur-sm opacity-0 group-hover:opacity-100 transition-all duration-300 flex items-center justify-center gap-4 z-20">
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleInvite();
+            }}
+            className="w-10 h-10 rounded-full bg-white text-black flex items-center justify-center hover:bg-gray-200 transition"
+            title="Convidar"
+          >
+            <UserPlusIcon size={18} />
+          </button>
           <button
             onClick={(e) => {
               e.preventDefault();
@@ -130,3 +147,4 @@ const LessonPlanCard: React.FC<LessonPlanCardProps> = ({
 };
 
 export default LessonPlanCard;
+

--- a/src/utils/http-request.ts
+++ b/src/utils/http-request.ts
@@ -88,6 +88,24 @@ export class HttpRequest {
     return response.data;
   }
 
+  async getLessonPlanById(id: string): Promise<ILessonPlan | null> {
+    try {
+      const token = await this.getToken();
+      const response = await axios.get(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/lesson-plans/${id}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Erro ao buscar o plano de aula:", error);
+      throw error;
+    }
+  }
+
   async createLessonPlan(
     name: string,
     icon: string
@@ -156,6 +174,31 @@ export class HttpRequest {
       return response.data;
     } catch (error) {
       console.error("Erro ao deletar o plano de aula:", error);
+      throw error;
+    }
+  }
+
+  async inviteUserToLessonPlan(
+    lesson_plan_id: string,
+    user_id: string
+  ): Promise<any> {
+    try {
+      const token = await this.getToken();
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_BACKEND_URL}/lesson-plans/inviteUser`,
+        {
+          lesson_plan_id,
+          user_id,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Erro ao entrar no plano de aula:", error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- add invite button to lesson plan card that copies share link
- add invite page to join a lesson plan
- support inviteUser API and fetching lesson plan by id

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689132e165e483258f6c26e5c5515907