### PR TITLE
Handle invite link authentication flow

### DIFF
--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -7,12 +7,14 @@ import Label from "@/components/form/Label";
 import Link from "next/link";
 import Notification from "@/components/ui/notification/Notification";
 import React from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function SignInForm() {
   const [email, setEmail] = React.useState("");
   const [password, setPassword] = React.useState("");
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect");
   const [notification, setNotification] = React.useState<{
     variant: "error" | "success";
     title: string;
@@ -31,7 +33,7 @@ export default function SignInForm() {
           variant: "success",
           title: "Login bem-sucedido! Redirecionando...",
         });
-        router.push("/lesson-plan");
+        router.push(redirect || "/lesson-plan");
       }
     } catch (error) {
       console.error("Login falhou:", error);
@@ -94,7 +96,11 @@ export default function SignInForm() {
               <p className="text-sm font-normal text-center text-gray-700 dark:text-gray-400 sm:text-start">
                 Não possui uma conta? {""}
                 <Link
-                  href="/signup"
+                  href={
+                    redirect
+                      ? `/signup?redirect=${encodeURIComponent(redirect)}`
+                      : "/signup"
+                  }
                   className="text-brand-500 hover:text-brand-600 dark:text-brand-400"
                 >
                   Criar conta

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -4,10 +4,10 @@ import { HttpRequest } from "@/utils/http-request";
 import Input from "@/components/form/input/InputField";
 import Label from "@/components/form/Label";
 import Link from "next/link";
-import Notification from "@/components/ui/notification/Notification"; 
+import Notification from "@/components/ui/notification/Notification";
 import React from "react";
 import Select from "../form/Select";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function SignUpForm() {
   const [email, setEmail] = React.useState("");
@@ -19,6 +19,8 @@ export default function SignUpForm() {
     title: string;
   } | null>(null);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect");
 
   const options = [
     { value: "TEACHER", label: "Professor" },
@@ -36,12 +38,13 @@ export default function SignUpForm() {
 
     try {
       await httpRequest.createUser(email, password, name, role);
+      await httpRequest.login(email, password);
 
       setNotification({
         variant: "success",
         title: "Usuário criado com sucesso! Redirecionando...",
       });
-      router.push("/signin");
+      router.push(redirect || "/lesson-plan");
 
     } catch (error) {
       console.error("Criação de usuário falhou:", error);
@@ -127,7 +130,11 @@ export default function SignUpForm() {
               <p className="text-sm font-normal text-center text-gray-700 dark:text-gray-400 sm:text-start">
                 Já possui uma conta?
                 <Link
-                  href="/signin"
+                  href={
+                    redirect
+                      ? `/signin?redirect=${encodeURIComponent(redirect)}`
+                      : "/signin"
+                  }
                   className="text-brand-500 hover:text-brand-600 dark:text-brand-400"
                 >
                   Entrar

--- a/src/components/lesson-plan/LessonPlanCard.tsx
+++ b/src/components/lesson-plan/LessonPlanCard.tsx
@@ -2,9 +2,7 @@
 
 import {
   MoreHorizontalIcon,
-  MoreVertical,
   PenIcon,
-  PencilIcon,
   Trash2Icon,
   UserPlusIcon,
 } from "lucide-react";


### PR DESCRIPTION
## Summary
- Redirect invite links to login when user is not authenticated and auto-join when logged in
- Preserve redirect through sign-in and sign-up forms and auto-login after registration
- Remove unused lesson plan card icon imports to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf6a723bd483259af1ddf24ffbc8b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Invite links now auto-join users to a lesson plan and navigate directly to the plan.
  * Sign-in and sign-up honor a redirect parameter, returning users to their intended page (default: Lesson Plans).
  * After sign-up, users are logged in automatically.

* Refactor
  * Simplified invite page by removing intermediate UI and button-driven flow.

* Style
  * Removed unused icons from the lesson plan card.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->