### PR TITLE
Wrap useSearchParams components with Suspense

### DIFF
--- a/src/app/(admin)/(home)/exercise/correction/[id]/page.tsx
+++ b/src/app/(admin)/(home)/exercise/correction/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { Suspense, useState, useEffect } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { useIndividualExerciseData } from "./useCorrectionExerciseData";
 import { HttpRequest } from "@/utils/http-request";
@@ -9,7 +9,8 @@ import LessonPlanBreadcrumb from "@/components/ui/breadcrumb/LessonPlanBreadCrum
 import StudentListSidebar from "@/components/correction/StudentListSidebar";
 import SummarySidebar from "@/components/correction/SummarySidebar";
 import IndividualCorrectionPanel from "@/components/correction/IndividualCorrectionPanel";
-const ExerciseCorrectionPage = () => {
+
+const ExerciseCorrectionPageContent = () => {
   const params = useParams();
   const searchParams = useSearchParams();
   const lessonPlanIdFromUrl = searchParams.get("lessonPlanId");
@@ -146,5 +147,11 @@ const ExerciseCorrectionPage = () => {
     </>
   );
 };
+
+const ExerciseCorrectionPage = () => (
+  <Suspense fallback={<div>Carregando...</div>}>
+    <ExerciseCorrectionPageContent />
+  </Suspense>
+);
 
 export default ExerciseCorrectionPage;

--- a/src/app/(full-width-pages)/(auth)/signin/page.tsx
+++ b/src/app/(full-width-pages)/(auth)/signin/page.tsx
@@ -1,5 +1,6 @@
 import SignInForm from "@/components/auth/SignInForm";
 import { Metadata } from "next";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Next.js SignIn Page | TailAdmin - Next.js Dashboard Template",
@@ -7,5 +8,9 @@ export const metadata: Metadata = {
 };
 
 export default function SignIn() {
-  return <SignInForm />;
+  return (
+    <Suspense fallback={<div>Carregando...</div>}>
+      <SignInForm />
+    </Suspense>
+  );
 }

--- a/src/app/(full-width-pages)/(auth)/signup/page.tsx
+++ b/src/app/(full-width-pages)/(auth)/signup/page.tsx
@@ -1,5 +1,6 @@
 import SignUpForm from "@/components/auth/SignUpForm";
 import { Metadata } from "next";
+import { Suspense } from "react";
 
 export const metadata: Metadata = {
   title: "Next.js SignUp Page | TailAdmin - Next.js Dashboard Template",
@@ -8,5 +9,9 @@ export const metadata: Metadata = {
 };
 
 export default function SignUp() {
-  return <SignUpForm />;
+  return (
+    <Suspense fallback={<div>Carregando...</div>}>
+      <SignUpForm />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap sign-in, sign-up, and exercise correction pages in Suspense to support `useSearchParams`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Outfit` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7019f6048325997619e59a2ef285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators (“Carregando...”) while content loads on Sign In, Sign Up, and Exercise Correction pages for smoother user experience.
* **Refactor**
  * Improved page structure to support loading states without changing routes or visible behavior beyond the new loading feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->